### PR TITLE
feat: prevent the Infrastructure NS being exposed

### DIFF
--- a/Markup/Sniffs/Next/InfrastructureExposedSniff.php
+++ b/Markup/Sniffs/Next/InfrastructureExposedSniff.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Markup\Sniffs\Next;
+
+use SlevomatCodingStandard\Helpers\UseStatement;
+use SlevomatCodingStandard\Helpers\UseStatementHelper;
+
+class InfrastructureExposedSniff implements \PHP_CodeSniffer\Sniffs\Sniff
+{
+    private const INFRASTRUCTURE_LAYER_PATH = 'src/Next/Infrastructure/';
+    private const INFRASTRUCTURE_NS = 'Next\Infrastructure';
+
+    /**
+     * @return mixed[]
+     */
+    public function register()
+    {
+        return [
+            T_OPEN_TAG,
+        ];
+    }
+
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile
+     * @param int $openTagPointer
+     */
+    public function process(\PHP_CodeSniffer\Files\File $phpcsFile, $openTagPointer)
+    {
+        if (stripos($phpcsFile->getFilename(), self::INFRASTRUCTURE_LAYER_PATH) !== false) {
+            return;
+        }
+
+        $useStatements = UseStatementHelper::getUseStatements($phpcsFile, $openTagPointer);
+
+        /** @var UseStatement $useStatement */
+        foreach ($useStatements as $useStatement) {
+            if (stripos($useStatement->getFullyQualifiedTypeName(), self::INFRASTRUCTURE_NS) !== false) {
+                $phpcsFile->addError(
+                    sprintf(
+                        'Infrastructure cannot be referenced here as the implementation is configurable'
+                    ),
+                    $openTagPointer,
+                    'InfrastructureReference'
+                );
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Resolves #19 I've gone with banning any references in the code outside of `Next/Infrastructure` which passes on the the text editor branch with flying colours. 

An example error though

![screen shot 2018-03-28 at 11 14 31](https://user-images.githubusercontent.com/319498/38023079-36daa9e6-3279-11e8-89a3-83518672f652.png)

