### PR TITLE
feat/forbidden function use

### DIFF
--- a/Markup/Sniffs/Usage/ForbiddenFunctionSniff.php
+++ b/Markup/Sniffs/Usage/ForbiddenFunctionSniff.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Markup\Sniffs\Usage;
+
+use PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff as GenericForbiddenFunctionsSniff;
+
+class ForbiddenFunctionSniff extends GenericForbiddenFunctionsSniff
+{
+    protected $patternMatch = true;
+
+    public $forbiddenFunctions = [
+        '^json_encode$' => 'Markup\Json\Encoder::encode',
+        '^json_decode$' => 'Markup\Json\Encoder::decode',
+    ];
+}


### PR DESCRIPTION
As per https://github.com/usemarkup/phoenix/issues/4803. Prohibit use of json encode/decode in favour of Markup/Json package