### PR TITLE
fix: correct breaking config for CouplingBetweenObjects, and require at least 2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": ">=7.1",
         "phpstan/phpstan-shim": "@stable",
         "phpstan/phpstan-strict-rules": "@stable",
-        "phpmd/phpmd": "@stable",
+        "phpmd/phpmd": "^2.7",
         "squizlabs/php_codesniffer": "@stable",
         "slevomat/coding-standard": "@stable"
     }

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -20,7 +20,7 @@
     </rule>
     <rule ref="rulesets/design.xml/CouplingBetweenObjects">
         <properties>
-            <property name="minimum" value="21" />
+            <property name="maximum" value="21" />
         </properties>
     </rule>
 
@@ -38,6 +38,7 @@
     <rule ref="rulesets/cleancode.xml">
         <exclude name="BooleanArgumentFlag" />
         <exclude name="StaticAccess" />
+        <exclude name="MissingImport" />
     </rule>
 
     <rule ref="rulesets/controversial.xml" />


### PR DESCRIPTION
PHPMD has had a new 2.7 release, which has a couple of breaking changes for us - an additional rule that is enabled by default, and a fix to a previously-used config value. The result should be behaviour parity with PHPMD <2.7.