### PR TITLE
feat: remove rule to force *Action method naming in controller classes

### DIFF
--- a/Markup/Sniffs/Symfony/ControllerPublicMethodNamesSniff.php
+++ b/Markup/Sniffs/Symfony/ControllerPublicMethodNamesSniff.php
@@ -52,16 +52,6 @@ class ControllerPublicMethodNamesSniff implements \PHP_CodeSniffer\Sniffs\Sniff
         if (in_array($name, ['__construct', '__invoke'])) {
             return;
         }
-
-        if (substr($name, -6) !== 'Action') {
-            $phpcsFile->addError(
-                sprintf(
-                    'Controller public function name(%s) must end in *Action ', $name
-                ),
-                $openTagPointer,
-                'SymfonyControllerPublicMethodName'
-            );
-        }
     }
 
 }


### PR DESCRIPTION
The *Action naming is [not recommended](https://symfony.com/doc/current/best_practices/controllers.html#controller-action-naming) for Symfony 4+ and I would argue that having it as a rule doesn't provide benefit today (given also that we also have existing methods breaking this rule that would need to be changed) or at all. If the concern is controller classes having state we could have a more precise sniff (if this is significant enough of an issue to warrant it).