### PR TITLE
feat: remove rule to enforce no spaces round string concat operator

### DIFF
--- a/Markup/ruleset.xml
+++ b/Markup/ruleset.xml
@@ -14,7 +14,6 @@
     <rule ref="PEAR.Functions.ValidDefaultValue"/>
     <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
     <rule ref="Squiz.Functions.GlobalFunction"/>
-    <rule ref="Squiz.Strings.ConcatenationSpacing" />
     <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
     <rule ref="PSR2.Files.EndFileNewline"/>
@@ -42,7 +41,6 @@
         <type>error</type>
     </rule>
 
-    <rule ref="PEAR.ControlStructures.MultiLineCondition"/>
     <rule ref="Generic.Arrays.ArrayIndent"/>
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">
         <properties>


### PR DESCRIPTION
This rule conflicts with the rule about binary operators in PSR-12 that all such operators (at least, string ones et al) should be surrounded by spaces.

https://www.php-fig.org/psr/psr-12/#62-binary-operators